### PR TITLE
Support for Laravel 5.5 to 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": "^7.2.5",
-        "illuminate/database": "^7.0"
+        "illuminate/database": "~5.5.0|~5.6.0|~5.7.0|~5.8.0|^6.0|^7.0"
     },
     "require-dev": {
         "laravel/homestead": "^10.0",


### PR DESCRIPTION
In current version, composer install will fail for any Laravel version that is not v7
in my case it failed for v5.7