### PR TITLE
Trim compiled expressions

### DIFF
--- a/src/Query/Grammars/CompilesExpressions.php
+++ b/src/Query/Grammars/CompilesExpressions.php
@@ -3,6 +3,7 @@
 namespace Staudenmeir\LaravelCte\Query\Grammars;
 
 use Illuminate\Database\Query\Builder;
+use Illuminate\Support\Str;
 
 trait CompilesExpressions
 {
@@ -81,7 +82,12 @@ trait CompilesExpressions
 
         $recursionLimit = $this->compileRecursionLimit($query);
 
-        return $expressions.' '.parent::compileInsertUsing($query, $columns, $sql).' '.$recursionLimit;
+        $compiled = parent::compileInsertUsing($query, $columns, $sql);
+
+        return (string) Str::of($compiled)
+            ->prepend($expressions, ' ')
+            ->append(' ', $recursionLimit)
+            ->trim();
     }
 
     /**
@@ -93,7 +99,11 @@ trait CompilesExpressions
      */
     public function compileUpdate(Builder $query, array $values)
     {
-        return $this->compileExpressions($query).' '.parent::compileUpdate($query, $values);
+        $compiled = parent::compileUpdate($query, $values);
+
+        return (string) Str::of($compiled)
+            ->prepend($this->compileExpressions($query), ' ')
+            ->trim();
     }
 
     /**
@@ -120,6 +130,10 @@ trait CompilesExpressions
      */
     public function compileDelete(Builder $query)
     {
-        return $this->compileExpressions($query).' '.parent::compileDelete($query);
+        $compiled = parent::compileDelete($query);
+
+        return (string) Str::of($compiled)
+            ->prepend($this->compileExpressions($query), ' ')
+            ->trim();
     }
 }

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -197,7 +197,7 @@ class QueryTest extends TestCase
     public function testInsertUsingWithRecursionLimit()
     {
         $builder = $this->getBuilder('SqlServer');
-        $query = ' insert into [posts] ([id]) select [id] from [users] option (maxrecursion 100)';
+        $query = 'insert into [posts] ([id]) select [id] from [users] option (maxrecursion 100)';
         $builder->getConnection()->expects($this->once())->method('insert')->with($query, []);
 
         $builder->from('posts')


### PR DESCRIPTION
When there's no common table expression in the query, some methods in the query grammar will return the original compiled string with a trailing (and/or) leading space. 

When performing an update query without CTE, I discovered that in some cases the Eloquent model did not update as expected (as it used to) when this package is installed.

When I removed the leading space in `Staudenmeir\LaravelCte\Query\Grammars\ CompilesExpressions::compileUpdate()`, this was solved. I didn't reproduce the exact reason for this, because when I look at `Illuminate\Database\Query\Grammars::compileUpdate()`, the returning value is also being trimmed for some (assumably valid) reason.

I applied the trimming on 2 other methods within the trait as well, as I expect this will do no harm and might solve any issue here as well.