### PR TITLE
Fix implode for version 1

### DIFF
--- a/src/Query/Grammars/CompilesExpressions.php
+++ b/src/Query/Grammars/CompilesExpressions.php
@@ -38,7 +38,7 @@ trait CompilesExpressions
             $statements[] = $this->wrapTable($expression['name']).' '.$columns.'as ('.$expression['query'].')';
         }
 
-        return 'with '.$recursive.implode($statements, ', ');
+        return 'with '.$recursive.implode(', ', $statements);
     }
 
     /**


### PR DESCRIPTION
Hi, I am using staudenmeir/laravel-adjacency-list version 1.0.4, because we're using Laravel 5.5. 

The package staudenmeir/laravel-adjacency-list requires staudenmeir/laravel-cte: ^1.0.3, which throws the following error: `ErrorException: implode(): Passing glue string after array is deprecated`.

This PR fixes the issue for Laravel 5.5 users.