### PR TITLE
update phpunit configuration to move away from the current deprecated schema

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,21 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         backupGlobals="false"
          colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnError="false"
-         stopOnFailure="false"
-         verbose="true"
->
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd"
+         cacheResultFile=".phpunit.cache">
     <testsuites>
         <testsuite name="LaravelCte Test Suite">
             <directory suffix="Test.php">./tests</directory>
         </testsuite>
     </testsuites>
-    <coverage processUncoveredFiles="true">
+    <coverage>
         <include>
             <directory suffix=".php">./src</directory>
         </include>


### PR DESCRIPTION
While setting up my fork to try and create a Singlestore connector, I saw that tests were failing with the following message.
> 1) Your XML configuration validates against a deprecated schema. Migrate your XML configuration using "--migrate-configuration"!

In this pull request I have run `vendor/bin/phpunit --migrate-configuration` and committed the changes made.